### PR TITLE
Adição de alunos sem grupo quando não especificado o grupo para o relatório.

### DIFF
--- a/dump.php
+++ b/dump.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -15,23 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-define('NO_MOODLE_COOKIES', true); // session not used here
+define('NO_MOODLE_COOKIES', true); // Session not used here.
 require_once '../../../config.php';
-require_once($CFG->dirroot.'/grade/export/csv/grade_export_csv.php');
+require_once($CFG->dirroot . '/grade/export/csv/grade_export_csv.php');
 
-$id                 = required_param('id', PARAM_INT);
-$groupid            = optional_param('groupid', 0, PARAM_INT);
-$itemids            = required_param('itemids', PARAM_RAW);
-$exportfeedback     = optional_param('export_feedback', 0, PARAM_BOOL);
-$displaytype        = optional_param('displaytype', $CFG->grade_export_displaytype, PARAM_RAW);
-$decimalpoints      = optional_param('decimalpoints', $CFG->grade_export_decimalpoints, PARAM_INT);
-$onlyactive         = optional_param('export_onlyactive', 0, PARAM_BOOL);
+$id = required_param('id', PARAM_INT);
+$groupid = optional_param('groupid', 0, PARAM_INT);
+$itemids = required_param('itemids', PARAM_RAW);
+$exportfeedback = optional_param('export_feedback', 0, PARAM_BOOL);
+$displaytype = optional_param('displaytype', $CFG->grade_export_displaytype, PARAM_RAW);
+$decimalpoints = optional_param('decimalpoints', $CFG->grade_export_decimalpoints, PARAM_INT);
+$onlyactive = optional_param('export_onlyactive', 0, PARAM_BOOL);
 
-if (!$course = $DB->get_record('course', array('id'=>$id))) {
+if (!$course = $DB->get_record('course', array('id' => $id))) {
     print_error('invalidcourseid');
 }
 
-require_user_key_login('grade/export', $id); // we want different keys for each course
+require_user_key_login('grade/export', $id); // We want different keys for each course.
 
 if (empty($CFG->gradepublishing)) {
     print_error('gradepubdisable');
@@ -48,7 +47,7 @@ if (!groups_group_visible($groupid, $COURSE)) {
 
 // Get all url parameters and create an object to simulate a form submission.
 $formdata = grade_export::export_bulk_export_data($id, $itemids, $exportfeedback, $onlyactive, $displaytype,
-        $decimalpoints);
+    $decimalpoints);
 
 $export = new grade_export_csv($course, $groupid, $formdata);
 $export->print_grades();

--- a/export.php
+++ b/export.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -16,13 +15,13 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 require_once '../../../config.php';
-require_once $CFG->dirroot.'/grade/export/lib.php';
+require_once $CFG->dirroot . '/grade/export/lib.php';
 require_once 'grade_export_csv.php';
 
-$id                = required_param('id', PARAM_INT); // course id
-$PAGE->set_url('/grade/export/csv/export.php', array('id'=>$id));
+$id = required_param('id', PARAM_INT); // Course id.
+$PAGE->set_url('/grade/export/csv/export.php', array('id' => $id));
 
-if (!$course = $DB->get_record('course', array('id'=>$id))) {
+if (!$course = $DB->get_record('course', array('id' => $id))) {
     print_error('invalidcourseid');
 }
 
@@ -37,7 +36,8 @@ require_capability('gradeexport/csv:view', $context);
 // If you use this method without this check, will break the direct grade exporting (without publishing).
 $key = optional_param('key', '', PARAM_RAW);
 if (!empty($CFG->gradepublishing) && !empty($key)) {
-    print_grade_page_head($COURSE->id, 'export', 'csv', get_string('exportto', 'grades') . ' ' . get_string('pluginname', 'gradeexport_csv'));
+    $heading = get_string('exportto', 'grades') . ' ' . get_string('pluginname', 'gradeexport_csv');
+    print_grade_page_head($COURSE->id, 'export', 'csv', $heading);
 }
 
 if (groups_get_course_groupmode($COURSE) == SEPARATEGROUPS and !has_capability('moodle/site:accessallgroups', $context)) {
@@ -51,7 +51,7 @@ $export = new grade_export_csv($course, $groupid, $formdata);
 
 // If the gradepublishing is enabled and user key is selected print the grade publishing link.
 if (!empty($CFG->gradepublishing) && !empty($key)) {
-    groups_print_course_menu($course, 'index.php?id='.$id);
+    groups_print_course_menu($course, 'index.php?id=' . $id);
     echo $export->get_grade_publishing_url();
     echo $OUTPUT->footer();
 } else {

--- a/grade_export_csv.php
+++ b/grade_export_csv.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -18,8 +17,7 @@
 require_once($CFG->dirroot . '/grade/export/lib.php');
 require_once('lib.php');
 
-class grade_export_csv extends grade_export
-{
+class grade_export_csv extends grade_export {
 
     public $plugin = 'csv';
 
@@ -29,8 +27,7 @@ class grade_export_csv extends grade_export
      * @param int $groupid id of selected group, 0 means all
      * @param stdClass $formdata The validated data from the grade export form.
      */
-    public function __construct($course, $groupid, $formdata)
-    {
+    public function __construct($course, $groupid, $formdata) {
         parent::__construct($course, $groupid, $formdata);
 
         // Overrides.
@@ -40,8 +37,7 @@ class grade_export_csv extends grade_export
     /**
      * To be implemented by child classes
      */
-    public function print_grades()
-    {
+    public function print_grades() {
         global $CFG;
         require_once($CFG->dirroot . '/lib/excellib.class.php');
 
@@ -49,17 +45,17 @@ class grade_export_csv extends grade_export
 
         $strgrades = get_string('grades');
 
-        // Calculate file name
+        // Calculate file name.
         $shortname = format_string($this->course->shortname, true, array('context' => context_course::instance($this->course->id)));
         $downloadfilename = clean_filename("$shortname $strgrades.csv");
-        // Creating a workbook
+        // Creating a workbook.
         $workbook = new MoodleExcelWorkbook("-");
-        // Sending HTTP headers
+        // Sending HTTP headers.
         $workbook->send($downloadfilename);
-        // Adding the worksheet
+        // Adding the worksheet.
         $mycsv = $workbook->add_worksheet($strgrades);
 
-        // Print names of all the fields
+        // Print names of all the fields.
         $profilefields = $this->get_user_profile_fields($this->course->id, $this->usercustomfields);
         foreach ($profilefields as $id => $field) {
             $mycsv->write_string(0, $id, $field->fullname);
@@ -73,7 +69,7 @@ class grade_export_csv extends grade_export
             foreach ($this->displaytype as $gradedisplayname => $gradedisplayconst) {
                 $mycsv->write_string(0, $pos++, $this->format_column_name($grade_item, false, $gradedisplayname));
             }
-            // Add a column_feedback column
+            // Add a column_feedback column.
             if ($this->export_feedback) {
                 $mycsv->write_string(0, $pos++, $this->format_column_name($grade_item, true));
             }
@@ -85,20 +81,28 @@ class grade_export_csv extends grade_export
         $i = 0;
         $geub = new grade_export_update_buffer();
         $gui = new csv_graded_users_iterator($this->course, $this->columns, $this->groupid, 'go.name', 'ASC', 'u.firstname', 'ASC');
-        $gui->require_active_enrolment($this->onlyactive);
         $gui->allow_user_custom_fields($this->usercustomfields);
+        $gui->require_active_enrolment($this->onlyactive);
         $gui->init();
 
+        $withoutgroup = new graded_users_iterator($this->course, $this->columns, $this->groupid);
+        $withoutgroup->require_active_enrolment($this->onlyactive);
+        $withoutgroup->allow_user_custom_fields($this->usercustomfields);
+        $withoutgroup->init();
 
+        // Only students in group.
+        $ingroups = array();
         while ($userdata = $gui->next_user()) {
             $i++;
             $user = $userdata->user;
 
+            $ingroups[] = $user->id;
 
             foreach ($profilefields as $id => $field) {
                 $fieldvalue = $this->get_user_field_value($user, $field);
                 $mycsv->write_string($i, $id, $fieldvalue);
             }
+
             $j = count($profilefields);
             if (!$this->onlyactive) {
                 $issuspended = ($user->suspendedenrolment) ? get_string('yes') : '';
@@ -116,7 +120,7 @@ class grade_export_csv extends grade_export
                         $mycsv->write_string($i, $j++, $gradestr);
                     }
                 }
-                // writing feedback if requested
+                // Writing feedback if requested.
                 if ($this->export_feedback) {
                     $mycsv->write_string($i, $j++, $this->format_feedback($userdata->feedbacks[$itemid]));
                 }
@@ -124,10 +128,61 @@ class grade_export_csv extends grade_export
             // Time exported.
             $mycsv->write_string($i, $j++, time());
         }
+
         $gui->close();
+
+        if ($this->groupid) {
+            $workbook->close();
+            exit;
+        }
+
+        $i = 0;
+
+        // Grades from students without group.
+        while ($userdata = $withoutgroup->next_user()) {
+            $i++;
+            $user = $userdata->user;
+
+            if (in_array($user->id, $ingroups)) {
+                continue;
+            }
+
+            foreach ($profilefields as $id => $field) {
+                $fieldvalue = $this->get_user_field_value($user, $field);
+                $mycsv->write_string($i, $id, $fieldvalue);
+            }
+
+            $j = count($profilefields);
+            if (!$this->onlyactive) {
+                $issuspended = ($user->suspendedenrolment) ? get_string('yes') : '';
+                $mycsv->write_string($i, $j++, $issuspended);
+            }
+            foreach ($userdata->grades as $itemid => $grade) {
+                if ($export_tracking) {
+                    $status = $geub->track($grade);
+                }
+
+                foreach ($this->displaytype as $gradedisplayconst) {
+                    $gradestr = $this->format_grade($grade, $gradedisplayconst);
+                    if (is_numeric($gradestr)) {
+                        $mycsv->write_number($i, $j++, $gradestr);
+                    } else {
+                        $mycsv->write_string($i, $j++, $gradestr);
+                    }
+                }
+                // Writing feedback if requested.
+                if ($this->export_feedback) {
+                    $mycsv->write_string($i, $j++, $this->format_feedback($userdata->feedbacks[$itemid]));
+                }
+            }
+            // Time exported.
+            $mycsv->write_string($i, $j++, time());
+        }
+
+        $withoutgroup->close();
         $geub->close();
 
-        /// Close the workbook
+        // Close the workbook.
         $workbook->close();
 
         exit;
@@ -139,12 +194,13 @@ class grade_export_csv extends grade_export
      * @param int $courseid
      * @param bool $includecustomfields
      * @return array An array of stdClass instances with customid, shortname, datatype, default and fullname fields
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    protected function get_user_profile_fields($courseid, $includecustomfields = false)
-    {
+    protected function get_user_profile_fields($courseid, $includecustomfields = false) {
         global $CFG, $DB;
 
-        // Gets the fields that have to be hidden
+        // Gets the fields that have to be hidden.
         $hiddenfields = array_map('trim', explode(',', $CFG->hiddenuserfields));
         $context = context_course::instance($courseid);
         $canseehiddenfields = has_capability('moodle/course:viewhiddenuserfields', $context);
@@ -153,8 +209,8 @@ class grade_export_csv extends grade_export
         }
 
         $fields = array();
-        require_once($CFG->dirroot . '/user/lib.php');                // Loads user_get_default_fields()
-        require_once($CFG->dirroot . '/user/profile/lib.php');        // Loads constants, such as PROFILE_VISIBLE_ALL
+        require_once($CFG->dirroot . '/user/lib.php');                // Loads user_get_default_fields().
+        require_once($CFG->dirroot . '/user/profile/lib.php');        // Loads constants, such as PROFILE_VISIBLE_ALL.
         $userdefaultfields = user_get_default_fields();
 
         // Sets the list of profile fields
@@ -174,14 +230,14 @@ class grade_export_csv extends grade_export
             }
         }
 
-        // Adicionado na mao o polo do aluno
+        // Adicionado na mao o polo do aluno.
         $obj = new stdClass();
         $obj->customid = 0;
         $obj->shortname = 'group';
         $obj->fullname = get_string('group');
         $fields[] = $obj;
 
-        // Sets the list of custom profile fields
+        // Sets the list of custom profile fields.
         $customprofilefields = array_map('trim', explode(',', $CFG->grade_export_customprofilefields));
         if ($includecustomfields && !empty($customprofilefields)) {
             list($wherefields, $whereparams) = $DB->get_in_or_equal($customprofilefields);
@@ -212,11 +268,11 @@ class grade_export_csv extends grade_export
         }
 
         $fields = array_filter($fields, function ($field) {
-            // Prevents add two fullname fields and discards first and lastname fields
+            // Prevents add two fullname fields and discards first and lastname fields.
             return !in_array($field->shortname, array('firstname', 'lastname', 'fullname'));
         });
 
-        // Sets fullname field for user
+        // Sets fullname field for user.
         $obj = new stdClass();
         $obj->customid = 0;
         $obj->shortname = 'fullname';
@@ -233,8 +289,7 @@ class grade_export_csv extends grade_export
      * @param stdClass $field object
      * @return string value of the field
      */
-    protected function get_user_field_value($user, $field)
-    {
+    protected function get_user_field_value($user, $field) {
         if (!empty($field->customid)) {
             $fieldname = 'customfield_' . $field->shortname;
             if (!empty($user->{$fieldname}) || is_numeric($user->{$fieldname})) {

--- a/grade_export_csv.php
+++ b/grade_export_csv.php
@@ -15,236 +15,243 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-require_once($CFG->dirroot.'/grade/export/lib.php');
+require_once($CFG->dirroot . '/grade/export/lib.php');
 require_once('lib.php');
 
-class grade_export_csv extends grade_export {
+class grade_export_csv extends grade_export
+{
 
-  public $plugin = 'csv';
+    public $plugin = 'csv';
 
-  /**
-  * Constructor should set up all the private variables ready to be pulled
-  * @param object $course
-  * @param int $groupid id of selected group, 0 means all
-  * @param stdClass $formdata The validated data from the grade export form.
-  */
-  public function __construct($course, $groupid, $formdata) {
-    parent::__construct($course, $groupid, $formdata);
+    /**
+     * Constructor should set up all the private variables ready to be pulled
+     * @param object $course
+     * @param int $groupid id of selected group, 0 means all
+     * @param stdClass $formdata The validated data from the grade export form.
+     */
+    public function __construct($course, $groupid, $formdata)
+    {
+        parent::__construct($course, $groupid, $formdata);
 
-    // Overrides.
-    $this->usercustomfields = true;
-  }
-
-  /**
-  * To be implemented by child classes
-  */
-  public function print_grades() {
-    global $CFG;
-    require_once($CFG->dirroot.'/lib/excellib.class.php');
-
-    $export_tracking = $this->track_exports();
-
-    $strgrades = get_string('grades');
-
-    // Calculate file name
-    $shortname = format_string($this->course->shortname, true, array('context' => context_course::instance($this->course->id)));
-    $downloadfilename = clean_filename("$shortname $strgrades.csv");
-    // Creating a workbook
-    $workbook = new MoodleExcelWorkbook("-");
-    // Sending HTTP headers
-    $workbook->send($downloadfilename);
-    // Adding the worksheet
-    $mycsv = $workbook->add_worksheet($strgrades);
-
-    // Print names of all the fields
-    $profilefields = $this->get_user_profile_fields($this->course->id, $this->usercustomfields);
-    foreach ($profilefields as $id => $field) {
-      $mycsv->write_string(0, $id, $field->fullname);
+        // Overrides.
+        $this->usercustomfields = true;
     }
 
-    $pos = count($profilefields);
-    if (!$this->onlyactive) {
-      $mycsv->write_string(0, $pos++, get_string("suspended"));
-    }
-    foreach ($this->columns as $grade_item) {
-      foreach ($this->displaytype as $gradedisplayname => $gradedisplayconst) {
-        $mycsv->write_string(0, $pos++, $this->format_column_name($grade_item, false, $gradedisplayname));
-      }
-      // Add a column_feedback column
-      if ($this->export_feedback) {
-        $mycsv->write_string(0, $pos++, $this->format_column_name($grade_item, true));
-      }
-    }
-    // Last downloaded column header.
-    $mycsv->write_string(0, $pos++, get_string('timeexported', 'gradeexport_csv'));
+    /**
+     * To be implemented by child classes
+     */
+    public function print_grades()
+    {
+        global $CFG;
+        require_once($CFG->dirroot . '/lib/excellib.class.php');
 
-    // Print all the lines of data.
-    $i = 0;
-    $geub = new grade_export_update_buffer();
-    $gui = new csv_graded_users_iterator($this->course, $this->columns, $this->groupid, 'go.name', 'ASC', 'u.firstname', 'ASC');
-    $gui->require_active_enrolment($this->onlyactive);
-    $gui->allow_user_custom_fields($this->usercustomfields);
-    $gui->init();
+        $export_tracking = $this->track_exports();
 
-    while ($userdata = $gui->next_user()) {
-      $i++;
-      $user = $userdata->user;
+        $strgrades = get_string('grades');
 
-      foreach ($profilefields as $id => $field) {
-        $fieldvalue = $this->get_user_field_value($user, $field);
-        $mycsv->write_string($i, $id, $fieldvalue);
-      }
-      $j = count($profilefields);
-      if (!$this->onlyactive) {
-        $issuspended = ($user->suspendedenrolment) ? get_string('yes') : '';
-        $mycsv->write_string($i, $j++, $issuspended);
-      }
-      foreach ($userdata->grades as $itemid => $grade) {
-        if ($export_tracking) {
-          $status = $geub->track($grade);
+        // Calculate file name
+        $shortname = format_string($this->course->shortname, true, array('context' => context_course::instance($this->course->id)));
+        $downloadfilename = clean_filename("$shortname $strgrades.csv");
+        // Creating a workbook
+        $workbook = new MoodleExcelWorkbook("-");
+        // Sending HTTP headers
+        $workbook->send($downloadfilename);
+        // Adding the worksheet
+        $mycsv = $workbook->add_worksheet($strgrades);
+
+        // Print names of all the fields
+        $profilefields = $this->get_user_profile_fields($this->course->id, $this->usercustomfields);
+        foreach ($profilefields as $id => $field) {
+            $mycsv->write_string(0, $id, $field->fullname);
         }
-        foreach ($this->displaytype as $gradedisplayconst) {
-          $gradestr = $this->format_grade($grade, $gradedisplayconst);
-          if (is_numeric($gradestr)) {
-            $mycsv->write_number($i, $j++, $gradestr);
-          } else {
-            $mycsv->write_string($i, $j++, $gradestr);
-          }
+
+        $pos = count($profilefields);
+        if (!$this->onlyactive) {
+            $mycsv->write_string(0, $pos++, get_string("suspended"));
         }
-        // writing feedback if requested
-        if ($this->export_feedback) {
-          $mycsv->write_string($i, $j++, $this->format_feedback($userdata->feedbacks[$itemid]));
+        foreach ($this->columns as $grade_item) {
+            foreach ($this->displaytype as $gradedisplayname => $gradedisplayconst) {
+                $mycsv->write_string(0, $pos++, $this->format_column_name($grade_item, false, $gradedisplayname));
+            }
+            // Add a column_feedback column
+            if ($this->export_feedback) {
+                $mycsv->write_string(0, $pos++, $this->format_column_name($grade_item, true));
+            }
         }
-      }
-      // Time exported.
-      $mycsv->write_string($i, $j++, time());
+        // Last downloaded column header.
+        $mycsv->write_string(0, $pos++, get_string('timeexported', 'gradeexport_csv'));
+
+        // Print all the lines of data.
+        $i = 0;
+        $geub = new grade_export_update_buffer();
+        $gui = new csv_graded_users_iterator($this->course, $this->columns, $this->groupid, 'go.name', 'ASC', 'u.firstname', 'ASC');
+        $gui->require_active_enrolment($this->onlyactive);
+        $gui->allow_user_custom_fields($this->usercustomfields);
+        $gui->init();
+
+
+        while ($userdata = $gui->next_user()) {
+            $i++;
+            $user = $userdata->user;
+
+
+            foreach ($profilefields as $id => $field) {
+                $fieldvalue = $this->get_user_field_value($user, $field);
+                $mycsv->write_string($i, $id, $fieldvalue);
+            }
+            $j = count($profilefields);
+            if (!$this->onlyactive) {
+                $issuspended = ($user->suspendedenrolment) ? get_string('yes') : '';
+                $mycsv->write_string($i, $j++, $issuspended);
+            }
+            foreach ($userdata->grades as $itemid => $grade) {
+                if ($export_tracking) {
+                    $status = $geub->track($grade);
+                }
+                foreach ($this->displaytype as $gradedisplayconst) {
+                    $gradestr = $this->format_grade($grade, $gradedisplayconst);
+                    if (is_numeric($gradestr)) {
+                        $mycsv->write_number($i, $j++, $gradestr);
+                    } else {
+                        $mycsv->write_string($i, $j++, $gradestr);
+                    }
+                }
+                // writing feedback if requested
+                if ($this->export_feedback) {
+                    $mycsv->write_string($i, $j++, $this->format_feedback($userdata->feedbacks[$itemid]));
+                }
+            }
+            // Time exported.
+            $mycsv->write_string($i, $j++, time());
+        }
+        $gui->close();
+        $geub->close();
+
+        /// Close the workbook
+        $workbook->close();
+
+        exit;
     }
-    $gui->close();
-    $geub->close();
 
-    /// Close the workbook
-    $workbook->close();
+    /**
+     * Returns an array of user profile fields to be included in export
+     *
+     * @param int $courseid
+     * @param bool $includecustomfields
+     * @return array An array of stdClass instances with customid, shortname, datatype, default and fullname fields
+     */
+    protected function get_user_profile_fields($courseid, $includecustomfields = false)
+    {
+        global $CFG, $DB;
 
-    exit;
-  }
-
-  /**
-  * Returns an array of user profile fields to be included in export
-  *
-  * @param int $courseid
-  * @param bool $includecustomfields
-  * @return array An array of stdClass instances with customid, shortname, datatype, default and fullname fields
-  */
-  protected function get_user_profile_fields($courseid, $includecustomfields = false) {
-    global $CFG, $DB;
-
-    // Gets the fields that have to be hidden
-    $hiddenfields = array_map('trim', explode(',', $CFG->hiddenuserfields));
-    $context = context_course::instance($courseid);
-    $canseehiddenfields = has_capability('moodle/course:viewhiddenuserfields', $context);
-    if ($canseehiddenfields) {
-      $hiddenfields = array();
-    }
-
-    $fields = array();
-    require_once($CFG->dirroot.'/user/lib.php');                // Loads user_get_default_fields()
-    require_once($CFG->dirroot.'/user/profile/lib.php');        // Loads constants, such as PROFILE_VISIBLE_ALL
-    $userdefaultfields = user_get_default_fields();
-
-    // Sets the list of profile fields
-    // $userprofilefields = array_map('trim', explode(',', $CFG->grade_export_userprofilefields));
-    $userprofilefields = array_map('trim', explode(',', 'fullname,email'));
-    if (!empty($userprofilefields)) {
-      foreach ($userprofilefields as $field) {
-        $field = trim($field);
-        if (in_array($field, $hiddenfields) || !in_array($field, $userdefaultfields)) {
-          continue;
+        // Gets the fields that have to be hidden
+        $hiddenfields = array_map('trim', explode(',', $CFG->hiddenuserfields));
+        $context = context_course::instance($courseid);
+        $canseehiddenfields = has_capability('moodle/course:viewhiddenuserfields', $context);
+        if ($canseehiddenfields) {
+            $hiddenfields = array();
         }
+
+        $fields = array();
+        require_once($CFG->dirroot . '/user/lib.php');                // Loads user_get_default_fields()
+        require_once($CFG->dirroot . '/user/profile/lib.php');        // Loads constants, such as PROFILE_VISIBLE_ALL
+        $userdefaultfields = user_get_default_fields();
+
+        // Sets the list of profile fields
+        // $userprofilefields = array_map('trim', explode(',', $CFG->grade_export_userprofilefields));
+        $userprofilefields = array_map('trim', explode(',', 'fullname,email'));
+        if (!empty($userprofilefields)) {
+            foreach ($userprofilefields as $field) {
+                $field = trim($field);
+                if (in_array($field, $hiddenfields) || !in_array($field, $userdefaultfields)) {
+                    continue;
+                }
+                $obj = new stdClass();
+                $obj->customid = 0;
+                $obj->shortname = $field;
+                $obj->fullname = get_string($field);
+                $fields[] = $obj;
+            }
+        }
+
+        // Adicionado na mao o polo do aluno
         $obj = new stdClass();
-        $obj->customid  = 0;
-        $obj->shortname = $field;
-        $obj->fullname  = get_string($field);
+        $obj->customid = 0;
+        $obj->shortname = 'group';
+        $obj->fullname = get_string('group');
         $fields[] = $obj;
-      }
-    }
 
-    // Adicionado na mao o polo do aluno
-    $obj = new stdClass();
-    $obj->customid  = 0;
-    $obj->shortname = 'group';
-    $obj->fullname  = get_string('group');
-    $fields[] = $obj;
-
-    // Sets the list of custom profile fields
-    $customprofilefields = array_map('trim', explode(',', $CFG->grade_export_customprofilefields));
-    if ($includecustomfields && !empty($customprofilefields)) {
-        list($wherefields, $whereparams) = $DB->get_in_or_equal($customprofilefields);
-        $customfields = $DB->get_records_sql("SELECT f.*
+        // Sets the list of custom profile fields
+        $customprofilefields = array_map('trim', explode(',', $CFG->grade_export_customprofilefields));
+        if ($includecustomfields && !empty($customprofilefields)) {
+            list($wherefields, $whereparams) = $DB->get_in_or_equal($customprofilefields);
+            $customfields = $DB->get_records_sql("SELECT f.*
                                                 FROM {user_info_field} f
                                                 JOIN {user_info_category} c ON f.categoryid=c.id
                                                 WHERE f.shortname $wherefields
                                                 ORDER BY c.sortorder ASC, f.sortorder ASC", $whereparams);
 
-        foreach ($customfields as $field) {
-            // Make sure we can display this custom field
-            if (!in_array($field->shortname, $customprofilefields)) {
-                continue;
-            } else if (in_array($field->shortname, $hiddenfields)) {
-                continue;
-            } else if ($field->visible != PROFILE_VISIBLE_ALL && !$canseehiddenfields) {
-                continue;
+            foreach ($customfields as $field) {
+                // Make sure we can display this custom field
+                if (!in_array($field->shortname, $customprofilefields)) {
+                    continue;
+                } else if (in_array($field->shortname, $hiddenfields)) {
+                    continue;
+                } else if ($field->visible != PROFILE_VISIBLE_ALL && !$canseehiddenfields) {
+                    continue;
+                }
+
+                $obj = new stdClass();
+                $obj->customid = $field->id;
+                $obj->shortname = $field->shortname;
+                $obj->fullname = format_string($field->name);
+                $obj->datatype = $field->datatype;
+                $obj->default = $field->defaultdata;
+                $fields[] = $obj;
             }
-
-            $obj = new stdClass();
-            $obj->customid  = $field->id;
-            $obj->shortname = $field->shortname;
-            $obj->fullname  = format_string($field->name);
-            $obj->datatype  = $field->datatype;
-            $obj->default   = $field->defaultdata;
-            $fields[] = $obj;
         }
-      }
 
-      $fields = array_filter($fields, function($field) {
-        // Prevents add two fullname fields and discards first and lastname fields
-        return !in_array($field->shortname, array('firstname', 'lastname', 'fullname'));
-      });
+        $fields = array_filter($fields, function ($field) {
+            // Prevents add two fullname fields and discards first and lastname fields
+            return !in_array($field->shortname, array('firstname', 'lastname', 'fullname'));
+        });
 
-      // Sets fullname field for user
-      $obj = new stdClass();
-      $obj->customid  = 0;
-      $obj->shortname = 'fullname';
-      $obj->fullname  = get_string('fullname');
-      array_unshift($fields, $obj);
+        // Sets fullname field for user
+        $obj = new stdClass();
+        $obj->customid = 0;
+        $obj->shortname = 'fullname';
+        $obj->fullname = get_string('fullname');
+        array_unshift($fields, $obj);
 
-      return $fields;
+        return $fields;
     }
 
     /**
-    * Returns the value of a field from a user record
-    *
-    * @param stdClass $user object
-    * @param stdClass $field object
-    * @return string value of the field
-    */
-    protected function get_user_field_value($user, $field) {
-      if (!empty($field->customid)) {
-        $fieldname = 'customfield_' . $field->shortname;
-        if (!empty($user->{$fieldname}) || is_numeric($user->{$fieldname})) {
-          $fieldvalue = $user->{$fieldname};
+     * Returns the value of a field from a user record
+     *
+     * @param stdClass $user object
+     * @param stdClass $field object
+     * @return string value of the field
+     */
+    protected function get_user_field_value($user, $field)
+    {
+        if (!empty($field->customid)) {
+            $fieldname = 'customfield_' . $field->shortname;
+            if (!empty($user->{$fieldname}) || is_numeric($user->{$fieldname})) {
+                $fieldvalue = $user->{$fieldname};
+            } else {
+                $fieldvalue = $field->default;
+            }
         } else {
-          $fieldvalue = $field->default;
-        }
-      } else {
 
-        if($field->shortname == 'fullname') {
-          $fieldvalue = $user->firstname . ' '. $user->lastname;
-        } else if ($field->shortname == 'group') {
-          $fieldvalue = $user->groupname;
-        } else {
-          $fieldvalue = $user->{$field->shortname};
+            if ($field->shortname == 'fullname') {
+                $fieldvalue = $user->firstname . ' ' . $user->lastname;
+            } else if ($field->shortname == 'group') {
+                $fieldvalue = $user->groupname;
+            } else {
+                $fieldvalue = $user->{$field->shortname};
+            }
         }
-      }
-      return $fieldvalue;
+        return $fieldvalue;
     }
-  }
+}

--- a/index.php
+++ b/index.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -16,14 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 require_once '../../../config.php';
-require_once $CFG->dirroot.'/grade/export/lib.php';
+require_once $CFG->dirroot . '/grade/export/lib.php';
 require_once 'grade_export_csv.php';
 
-$id = required_param('id', PARAM_INT); // course id
+$id = required_param('id', PARAM_INT); // Course id.
 
-$PAGE->set_url('/grade/export/csv/index.php', array('id'=>$id));
+$PAGE->set_url('/grade/export/csv/index.php', array('id' => $id));
 
-if (!$course = $DB->get_record('course', array('id'=>$id))) {
+if (!$course = $DB->get_record('course', array('id' => $id))) {
     print_error('invalidcourseid');
 }
 
@@ -33,7 +32,8 @@ $context = context_course::instance($id);
 require_capability('moodle/grade:export', $context);
 require_capability('gradeexport/csv:view', $context);
 
-print_grade_page_head($COURSE->id, 'export', 'csv', get_string('exportto', 'grades') . ' ' . get_string('pluginname', 'gradeexport_csv'));
+$heading = get_string('exportto', 'grades') . ' ' . get_string('pluginname', 'gradeexport_csv');
+print_grade_page_head($COURSE->id, 'export', 'csv', $heading);
 export_verify_grades($COURSE->id);
 
 if (!empty($CFG->gradepublishing)) {
@@ -49,7 +49,7 @@ $formoptions = array(
 
 $mform = new grade_export_form($actionurl, $formoptions);
 
-$groupmode    = groups_get_course_groupmode($course);   // Groups are being used
+$groupmode = groups_get_course_groupmode($course);   // Groups are being used.
 $currentgroup = groups_get_course_group($course, true);
 if ($groupmode == SEPARATEGROUPS and !$currentgroup and !has_capability('moodle/site:accessallgroups', $context)) {
     echo $OUTPUT->heading(get_string("notingroup"));
@@ -57,7 +57,7 @@ if ($groupmode == SEPARATEGROUPS and !$currentgroup and !has_capability('moodle/
     die;
 }
 
-groups_print_course_menu($course, 'index.php?id='.$id);
+groups_print_course_menu($course, 'index.php?id=' . $id);
 echo '<div class="clearer"></div>';
 
 $mform->display();

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017112900;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2018031600;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015113000;        // Requires this Moodle version
 $plugin->component = 'gradeexport_csv'; // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION

## Correções:

* Remove duplicidade de alunos na emissão do relatório por conta de registros duplicados em `groups_members`, caso haja.

* Inclusão de alunos sem grupo quando não especificado o grupo para emissão do relatório.